### PR TITLE
Doppelten Slash entfernt

### DIFF
--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -14,7 +14,7 @@ if (rex::isBackend()
 $pass = $addon->getConfig('password');
 $pass = md5($pass);
 ?>
-<a class="pull-right btn btn-primary" target="_blank" href="<?= $addon->getConfig('url')?>/index.php?module=Login&action=logme&login=<?= $addon->getConfig('user')?>&password=<?=$pass?>"><?=$addon->i18n('matomo_link')?></a>
+<a class="pull-right btn btn-primary" target="_blank" href="<?= $addon->getConfig('url')?>index.php?module=Login&action=logme&login=<?= $addon->getConfig('user')?>&password=<?=$pass?>"><?=$addon->i18n('matomo_link')?></a>
 
 
 <iframe id="matomoframe" src="<?= $addon->getConfig('url')?>index.php?module=Widgetize&action=iframe&moduleToWidgetize=Dashboard&actionToWidgetize=index&idSite=<?= $addon->getConfig('id')?>&period=week&date=yesterday&token_auth=<?= $addon->getConfig('token')?>


### PR DESCRIPTION
In der Dashboard-Ansicht hatte der Button "Matomo aufrufen" in der Domain einen doppelten Slash.